### PR TITLE
Minor GUI polish

### DIFF
--- a/src/tribler/gui/widgets/lazytableview.py
+++ b/src/tribler/gui/widgets/lazytableview.py
@@ -52,7 +52,6 @@ class TriblerContentTableView(QTableView):
 
     channel_clicked = pyqtSignal(dict)
     torrent_clicked = pyqtSignal(dict)
-    content_clicked = pyqtSignal(dict)
     torrent_doubleclicked = pyqtSignal(dict)
     edited_tags = pyqtSignal(dict)
 
@@ -119,6 +118,10 @@ class TriblerContentTableView(QTableView):
     def mousePressEvent(self, event: QMouseEvent) -> None:
         should_select_row = True
         index = self.indexAt(event.pos())
+        data_item = index.model().data_items[index.row()]
+        if data_item["type"] == SNIPPET:
+            should_select_row = False
+
         if index != self.delegate.no_index:
             # Check if we are clicking the 'edit tags' button
             if index in index.model().edit_tags_rects:
@@ -221,8 +224,6 @@ class TriblerContentTableView(QTableView):
         # Safely determine if the thing is a channel. A little bit hackish
         if data_item.get('type') in [CHANNEL_TORRENT, COLLECTION_NODE]:
             self.channel_clicked.emit(data_item)
-        elif data_item.get("type") == SNIPPET:
-            self.content_clicked.emit(data_item)
         elif data_item.get('type') == REGULAR_TORRENT:
             if not doubleclick:
                 self.torrent_clicked.emit(data_item)

--- a/src/tribler/gui/widgets/tablecontentdelegate.py
+++ b/src/tribler/gui/widgets/tablecontentdelegate.py
@@ -139,7 +139,7 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
         self.column_drawing_actions = []
         self.font_metrics = None
 
-        self.hovering_over_tag_edit_button = False
+        self.hovering_over_tag_edit_button: bool = False
         self.hovering_over_download_popular_torrent_button: int = -1
 
         # TODO: restore this behavior, so there is really some tolerance zone!


### PR DESCRIPTION
- Removed the (unused) `content_clicked` field.
- Disable selection of snippets.