### PR TITLE
Update KnowledgeEndpoint to allow editing statements through the GUI

### DIFF
--- a/src/tribler/core/components/knowledge/restapi/knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/knowledge_endpoint.py
@@ -41,7 +41,7 @@ class KnowledgeEndpoint(RESTEndpoint):
         self.app.add_routes(
             [
                 web.patch('/{infohash}', self.update_knowledge_entries),
-                web.get('/{infohash}/suggestions', self.get_suggestions),
+                web.get('/{infohash}/tag_suggestions', self.get_tag_suggestions),
             ]
         )
 
@@ -120,7 +120,7 @@ class KnowledgeEndpoint(RESTEndpoint):
         },
         description="This endpoint updates a particular torrent with the provided tags."
     )
-    async def get_suggestions(self, request):
+    async def get_tag_suggestions(self, request):
         """
         Get suggestions for a particular tag.
         """

--- a/src/tribler/core/components/knowledge/restapi/knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/knowledge_endpoint.py
@@ -1,5 +1,5 @@
 import binascii
-from typing import Optional, Set, Tuple
+from typing import Optional, Set, Tuple, Dict
 
 from aiohttp import web
 from aiohttp_apispec import docs
@@ -64,36 +64,45 @@ class KnowledgeEndpoint(RESTEndpoint):
         if not ih_valid:
             return error_response
 
-        # Validate whether the size of the tag is within the allowed range
-        tags = set(params["tags"])
-        for tag in tags:
-            if len(tag) < MIN_RESOURCE_LENGTH or len(tag) > MAX_RESOURCE_LENGTH:
+        # Validate whether the size of the tag is within the allowed range and filter out duplicate tags.
+        tags = set()
+        statements = []
+        for statement in params["statements"]:
+            obj = statement["object"]
+            if statement["predicate"] == ResourceType.TAG and \
+                    (len(obj) < MIN_RESOURCE_LENGTH or len(obj) > MAX_RESOURCE_LENGTH):
                 return RESTResponse({"error": "Invalid tag length"}, status=HTTP_BAD_REQUEST)
 
-        self.modify_tags(infohash, tags)
+            if obj not in tags:
+                tags.add(obj)
+                statements.append(statement)
+
+        self.modify_statements(infohash, statements)
 
         return RESTResponse({"success": True})
 
     @db_session
-    def modify_tags(self, infohash: str, new_tags: Set[str]):
+    def modify_statements(self, infohash: str, statements):
         """
-        Modify the tags of a particular content item.
+        Modify the statements of a particular content item.
         """
         if not self.community:
             return
 
-        # First, get the current tags and compute the diff between the old and new tags
-        old_tags = set(self.db.get_objects(infohash, predicate=ResourceType.TAG))
-        added_tags = new_tags - old_tags
-        removed_tags = old_tags - new_tags
+        # First, get the current statements and compute the diff between the old and new statements
+        old_statements = set([(stmt.predicate, stmt.object) for stmt in self.db.get_statements(infohash)])
+        new_statements = set([(stmt["predicate"], stmt["object"]) for stmt in statements])
+        added_statements = new_statements - old_statements
+        removed_statements = old_statements - new_statements
 
-        # Create individual tag operations for the added/removed tags
+        # Create individual statement operations for the added/removed statements
         public_key = self.community.key.pub().key_to_bin()
-        for tag in added_tags.union(removed_tags):
-            type_of_operation = Operation.ADD if tag in added_tags else Operation.REMOVE
+        for stmt in added_statements.union(removed_statements):
+            predicate, obj = stmt
+            type_of_operation = Operation.ADD if stmt in added_statements else Operation.REMOVE
             operation = StatementOperation(subject_type=ResourceType.TORRENT, subject=infohash,
-                                           predicate=ResourceType.TAG,
-                                           object=tag, operation=type_of_operation, clock=0,
+                                           predicate=predicate,
+                                           object=obj, operation=type_of_operation, clock=0,
                                            creator_public_key=public_key)
             operation.clock = self.db.get_clock(operation) + 1
             signature = self.community.sign(operation)

--- a/src/tribler/core/components/knowledge/restapi/knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/knowledge_endpoint.py
@@ -17,9 +17,9 @@ from tribler.core.utilities.utilities import froze_it
 
 
 @froze_it
-class TagsEndpoint(RESTEndpoint):
+class KnowledgeEndpoint(RESTEndpoint):
     """
-    Top-level endpoint for tags.
+    Top-level endpoint for knowledge management.
     """
 
     def __init__(self, db: KnowledgeDatabase, community: KnowledgeCommunity):
@@ -40,14 +40,14 @@ class TagsEndpoint(RESTEndpoint):
     def setup_routes(self):
         self.app.add_routes(
             [
-                web.patch('/{infohash}', self.update_tags_entries),
+                web.patch('/{infohash}', self.update_knowledge_entries),
                 web.get('/{infohash}/suggestions', self.get_suggestions),
             ]
         )
 
     @docs(
         tags=["General"],
-        summary="Update a particular torrent with tags.",
+        summary="Update the metadata associated with a particular torrent.",
         responses={
             200: {
                 "schema": schema(UpdateTagsResponse={'success': Boolean()})
@@ -55,12 +55,12 @@ class TagsEndpoint(RESTEndpoint):
             HTTP_BAD_REQUEST: {
                 "schema": HandledErrorSchema, 'example': {"error": "Invalid tag length"}},
         },
-        description="This endpoint updates a particular torrent with the provided tags."
+        description="This endpoint updates a particular torrent with the provided metadata."
     )
-    async def update_tags_entries(self, request):
+    async def update_knowledge_entries(self, request):
         params = await request.json()
         infohash = request.match_info["infohash"]
-        ih_valid, error_response = TagsEndpoint.validate_infohash(infohash)
+        ih_valid, error_response = KnowledgeEndpoint.validate_infohash(infohash)
         if not ih_valid:
             return error_response
 
@@ -116,7 +116,7 @@ class TagsEndpoint(RESTEndpoint):
         Get suggestions for a particular tag.
         """
         infohash = request.match_info["infohash"]
-        ih_valid, error_response = TagsEndpoint.validate_infohash(infohash)
+        ih_valid, error_response = KnowledgeEndpoint.validate_infohash(infohash)
         if not ih_valid:
             return error_response
 

--- a/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
@@ -98,8 +98,8 @@ async def test_get_suggestions_invalid_infohash(rest_api):
     """
     Test whether an error is returned if we fetch suggestions from content with an invalid infohash
     """
-    await do_request(rest_api, 'knowledge/3f3/suggestions', expected_code=400)
-    await do_request(rest_api, 'knowledge/3f3f/suggestions', expected_code=400)
+    await do_request(rest_api, 'knowledge/3f3/tag_suggestions', expected_code=400)
+    await do_request(rest_api, 'knowledge/3f3f/tag_suggestions', expected_code=400)
 
 
 async def test_get_suggestions(rest_api, knowledge_db):
@@ -108,7 +108,7 @@ async def test_get_suggestions(rest_api, knowledge_db):
     """
     infohash = b'a' * 20
     infohash_str = hexlify(infohash)
-    response = await do_request(rest_api, f'knowledge/{infohash_str}/suggestions')
+    response = await do_request(rest_api, f'knowledge/{infohash_str}/tag_suggestions')
     assert "suggestions" in response
     assert not response["suggestions"]
 
@@ -124,5 +124,5 @@ async def test_get_suggestions(rest_api, knowledge_db):
         _add_operation(op=Operation.ADD)
         _add_operation(op=Operation.REMOVE)
 
-    response = await do_request(rest_api, f'knowledge/{infohash_str}/suggestions')
+    response = await do_request(rest_api, f'knowledge/{infohash_str}/tag_suggestions')
     assert response["suggestions"] == ["test"]

--- a/src/tribler/core/components/restapi/restapi_component.py
+++ b/src/tribler/core/components/restapi/restapi_component.py
@@ -11,7 +11,7 @@ from tribler.core.components.gigachannel_manager.gigachannel_manager_component i
 from tribler.core.components.ipv8.ipv8_component import Ipv8Component
 from tribler.core.components.key.key_component import KeyComponent
 from tribler.core.components.knowledge.knowledge_component import KnowledgeComponent
-from tribler.core.components.knowledge.restapi.tags_endpoint import TagsEndpoint
+from tribler.core.components.knowledge.restapi.knowledge_endpoint import KnowledgeEndpoint
 from tribler.core.components.libtorrent.libtorrent_component import LibtorrentComponent
 from tribler.core.components.libtorrent.restapi.create_torrent_endpoint import CreateTorrentEndpoint
 from tribler.core.components.libtorrent.restapi.downloads_endpoint import DownloadsEndpoint
@@ -124,7 +124,7 @@ class RESTComponent(Component):
                        tags_db=knowledge_component.knowledge_db)
         self.maybe_add('/remote_query', RemoteQueryEndpoint, gigachannel_component.community,
                        metadata_store_component.mds)
-        self.maybe_add('/tags', TagsEndpoint, db=knowledge_component.knowledge_db,
+        self.maybe_add('/knowledge', KnowledgeEndpoint, db=knowledge_component.knowledge_db,
                        community=knowledge_component.community)
 
         if not isinstance(ipv8_component, NoneComponent):

--- a/src/tribler/gui/dialogs/addtagsdialog.py
+++ b/src/tribler/gui/dialogs/addtagsdialog.py
@@ -1,9 +1,10 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from PyQt5 import uic
 from PyQt5.QtCore import QModelIndex, QPoint, pyqtSignal
 from PyQt5.QtWidgets import QSizePolicy, QWidget
 
+from tribler.core.components.knowledge.db.knowledge_db import ResourceType
 from tribler.core.components.knowledge.knowledge_constants import MAX_RESOURCE_LENGTH, MIN_RESOURCE_LENGTH
 
 from tribler.gui.defs import TAG_HORIZONTAL_MARGIN
@@ -44,6 +45,8 @@ class AddTagsDialog(DialogContainer):
         self.update_window()
 
     def on_save_tags_button_clicked(self, _) -> None:
+        statements: List[Dict] = []
+
         # Sanity check the entered tags
         entered_tags = self.dialog_widget.edit_tags_input.get_entered_tags()
         for tag in entered_tags:
@@ -57,7 +60,12 @@ class AddTagsDialog(DialogContainer):
                 self.dialog_widget.error_text_label.setHidden(False)
                 return
 
-        self.save_button_clicked.emit(self.index, entered_tags)
+            statements.append({
+                "predicate": ResourceType.TAG,
+                "object": tag,
+            })
+
+        self.save_button_clicked.emit(self.index, statements)
 
     def on_received_suggestions(self, data: Dict) -> None:
         self.suggestions_loaded.emit()

--- a/src/tribler/gui/dialogs/addtagsdialog.py
+++ b/src/tribler/gui/dialogs/addtagsdialog.py
@@ -40,7 +40,7 @@ class AddTagsDialog(DialogContainer):
         self.dialog_widget.suggestions_container.hide()
 
         # Fetch suggestions
-        TriblerNetworkRequest(f"knowledge/{infohash}/suggestions", self.on_received_suggestions)
+        TriblerNetworkRequest(f"knowledge/{infohash}/tag_suggestions", self.on_received_tag_suggestions)
 
         self.update_window()
 
@@ -67,7 +67,7 @@ class AddTagsDialog(DialogContainer):
 
         self.save_button_clicked.emit(self.index, statements)
 
-    def on_received_suggestions(self, data: Dict) -> None:
+    def on_received_tag_suggestions(self, data: Dict) -> None:
         self.suggestions_loaded.emit()
         if data["suggestions"]:
             self.dialog_widget.suggestions_container.show()

--- a/src/tribler/gui/dialogs/addtagsdialog.py
+++ b/src/tribler/gui/dialogs/addtagsdialog.py
@@ -39,7 +39,7 @@ class AddTagsDialog(DialogContainer):
         self.dialog_widget.suggestions_container.hide()
 
         # Fetch suggestions
-        TriblerNetworkRequest(f"tags/{infohash}/suggestions", self.on_received_suggestions)
+        TriblerNetworkRequest(f"knowledge/{infohash}/suggestions", self.on_received_suggestions)
 
         self.update_window()
 

--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -10,8 +10,9 @@ from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QListWidget, QTableView, QTextEdit, QTreeWidget, QTreeWidgetItem
 
 import tribler.gui
-from tribler.core.components.reporter.reported_error import ReportedError
+from tribler.core.components.knowledge.db.knowledge_db import ResourceType
 from tribler.core.components.knowledge.knowledge_constants import MIN_RESOURCE_LENGTH
+from tribler.core.components.reporter.reported_error import ReportedError
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.utilities.rest_utils import path_to_url
@@ -733,7 +734,7 @@ def test_tags_dialog(window):
     screenshot(window, name="edit_tags_dialog_long_tag_removed")
 
     QTest.mouseClick(widget.content_table.add_tags_dialog.dialog_widget.save_button, Qt.LeftButton)
-    wait_for_signal(widget.content_table.edited_tags)
+    wait_for_signal(widget.content_table.edited_metadata)
     QTest.qWait(200)  # It can take a bit of time to hide the dialog
 
 
@@ -747,10 +748,13 @@ def test_no_tags(window):
     wait_for_list_populated(widget.content_table)
 
     idx = widget.content_table.model().index(0, 0)
-    widget.content_table.save_edited_tags(idx, [])  # Remove all tags
-    wait_for_signal(widget.content_table.edited_tags)
+    widget.content_table.save_edited_metadata(idx, [])  # Remove all tags
+    wait_for_signal(widget.content_table.edited_metadata)
     screenshot(window, name="content_item_no_tags")
 
     # Put some tags back (so further tests do not fail)
-    widget.content_table.save_edited_tags(idx, ["abc", "def"])
-    wait_for_signal(widget.content_table.edited_tags)
+    statements = []
+    for tag in ["abc", "def"]:
+        statements.append({"predicate": ResourceType.TAG, "object": tag})
+    widget.content_table.save_edited_metadata(idx, statements)
+    wait_for_signal(widget.content_table.edited_metadata)

--- a/src/tribler/gui/widgets/lazytableview.py
+++ b/src/tribler/gui/widgets/lazytableview.py
@@ -284,7 +284,7 @@ class TriblerContentTableView(QTableView):
     def save_edited_tags(self, index: QModelIndex, tags: List[str]):
         data_item = self.model().data_items[index.row()]
         TriblerNetworkRequest(
-            f"tags/{data_item['infohash']}",
+            f"knowledge/{data_item['infohash']}",
             lambda _, ind=index, tgs=tags: self.on_tags_edited(ind, tgs),
             raw_data=json.dumps({"tags": tags}),
             method='PATCH',

--- a/src/tribler/gui/widgets/lazytableview.py
+++ b/src/tribler/gui/widgets/lazytableview.py
@@ -1,10 +1,11 @@
 import json
-from typing import List
+from typing import List, Dict
 
 from PyQt5.QtCore import QEvent, QModelIndex, QRect, QTimer, Qt, pyqtSignal
 from PyQt5.QtGui import QGuiApplication, QMouseEvent, QMovie
 from PyQt5.QtWidgets import QAbstractItemView, QApplication, QHeaderView, QLabel, QTableView
 
+from tribler.core.components.knowledge.db.knowledge_db import ResourceType
 from tribler.core.components.metadata_store.db.orm_bindings.channel_node import LEGACY_ENTRY
 from tribler.core.components.metadata_store.db.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT, \
     SNIPPET
@@ -53,7 +54,7 @@ class TriblerContentTableView(QTableView):
     channel_clicked = pyqtSignal(dict)
     torrent_clicked = pyqtSignal(dict)
     torrent_doubleclicked = pyqtSignal(dict)
-    edited_tags = pyqtSignal(dict)
+    edited_metadata = pyqtSignal(dict)
 
     def __init__(self, parent=None):
         QTableView.__init__(self, parent)
@@ -202,7 +203,7 @@ class TriblerContentTableView(QTableView):
             self.add_tags_dialog.dialog_widget.edit_tags_input.set_tags(data_item.get("tags", ()))
         self.add_tags_dialog.dialog_widget.content_name_label.setText(data_item["name"])
         self.add_tags_dialog.show()
-        connect(self.add_tags_dialog.save_button_clicked, self.save_edited_tags)
+        connect(self.add_tags_dialog.save_button_clicked, self.save_edited_metadata)
 
     def on_download_popular_torrent_clicked(self, index: QModelIndex, torrent_index: int) -> None:
         data_item = index.model().data_items[index.row()]
@@ -270,22 +271,22 @@ class TriblerContentTableView(QTableView):
     def start_download_from_dataitem(self, data_item):
         self.window().start_download_from_uri(data_item2uri(data_item))
 
-    def on_tags_edited(self, index, tags):
+    def on_metadata_edited(self, index, statements: List[Dict]):
         if self.add_tags_dialog:
             self.add_tags_dialog.close_dialog()
             self.add_tags_dialog = None
 
         data_item = self.model().data_items[index.row()]
-        data_item["tags"] = tags
+        data_item["tags"] = [stmt["object"] for stmt in statements if stmt["predicate"] == ResourceType.TAG]
         self.redraw(index, True)
 
-        self.edited_tags.emit(data_item)
+        self.edited_metadata.emit(data_item)
 
-    def save_edited_tags(self, index: QModelIndex, tags: List[str]):
+    def save_edited_metadata(self, index: QModelIndex, statements: List[Dict]):
         data_item = self.model().data_items[index.row()]
         TriblerNetworkRequest(
             f"knowledge/{data_item['infohash']}",
-            lambda _, ind=index, tgs=tags: self.on_tags_edited(ind, tgs),
-            raw_data=json.dumps({"tags": tags}),
+            lambda _, ind=index, stmts=statements: self.on_metadata_edited(ind, statements),
+            raw_data=json.dumps({"statements": statements}),
             method='PATCH',
         )


### PR DESCRIPTION
TODO:
- [x] Rename `TagsEndpoint` to `KnowledgeEndpoint`
- [x] Modify the endpoint so that statements are processed instead of tags